### PR TITLE
6주차 과제 제출

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ bin/
 .DS_Store
 
 members.txt
+
+/src/main/resources/.env

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="assignment@localhost" uuid="57e5a98f-e4fa-4e6d-8171-023fa03b96e3">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <imported>true</imported>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306/assignment</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/build.gradle
+++ b/build.gradle
@@ -43,4 +43,14 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    //Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    //JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'com.auth0:java-jwt:4.4.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     //Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/org/sopt/Main.java
+++ b/src/main/java/org/sopt/Main.java
@@ -2,10 +2,12 @@ package org.sopt;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@ConfigurationPropertiesScan
 public class Main {
     public static void main(String[] args) {
         SpringApplication.run(Main.class, args);

--- a/src/main/java/org/sopt/domain/article/controller/ArticleController.java
+++ b/src/main/java/org/sopt/domain/article/controller/ArticleController.java
@@ -8,6 +8,7 @@ import org.sopt.domain.article.dto.response.ArticleCreateResponse;
 import org.sopt.domain.article.dto.response.ArticleDetailResponse;
 import org.sopt.domain.article.dto.response.ArticleListResponse;
 import org.sopt.domain.article.service.ArticleService;
+import org.sopt.global.annotation.LoginMemberId;
 import org.sopt.global.response.BaseResponse;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,8 +20,8 @@ public class ArticleController {
     private final ArticleService  articleService;
 
     @PostMapping
-    public BaseResponse<ArticleCreateResponse> createArticle(@Valid @RequestBody ArticleCreateRequest req){
-        return BaseResponse.ok(articleService.createArticle(req.toCommand()),"아티클 생성이 완료되었습니다.");
+    public BaseResponse<ArticleCreateResponse> createArticle(@LoginMemberId Long memberId, @Valid @RequestBody ArticleCreateRequest req){
+        return BaseResponse.ok(articleService.createArticle(memberId, req.toCommand()),"아티클 생성이 완료되었습니다.");
     }
 
     @GetMapping("{articleId}")

--- a/src/main/java/org/sopt/domain/article/dto/request/ArticleCreateRequest.java
+++ b/src/main/java/org/sopt/domain/article/dto/request/ArticleCreateRequest.java
@@ -7,9 +7,6 @@ import org.sopt.domain.article.service.dto.request.ArticleCreateCommand;
 import org.sopt.global.annotation.ValidTag;
 
 public record ArticleCreateRequest(
-        @NotNull
-        @Schema(description = "회원 ID" ,example = "1")
-        Long memberId,
 
         @NotBlank(message = "제목은 비어있을 수 없습니다.")
         @Schema(description = "제목", example = "아")
@@ -24,6 +21,6 @@ public record ArticleCreateRequest(
         String tag
 ) {
     public ArticleCreateCommand toCommand(){
-            return new ArticleCreateCommand(memberId, title, content, tag);
+            return new ArticleCreateCommand(title, content, tag);
     }
 }

--- a/src/main/java/org/sopt/domain/article/service/ArticleService.java
+++ b/src/main/java/org/sopt/domain/article/service/ArticleService.java
@@ -28,10 +28,10 @@ public class ArticleService {
 
     private final MemberServiceImpl memberService;
 
-    public ArticleCreateResponse createArticle(ArticleCreateCommand command) {
+    public ArticleCreateResponse createArticle(Long memberId, ArticleCreateCommand command) {
         checkTitleDuplicate(command.title());
 
-        Member member = memberService.findById(command.memberId());
+        Member member = memberService.findById(memberId);
 
         Article article = Article.create(command.title(),
                 command.content(),

--- a/src/main/java/org/sopt/domain/article/service/dto/request/ArticleCreateCommand.java
+++ b/src/main/java/org/sopt/domain/article/service/dto/request/ArticleCreateCommand.java
@@ -1,7 +1,6 @@
 package org.sopt.domain.article.service.dto.request;
 
 public record ArticleCreateCommand(
-        Long memberId,
 
         String title,
 

--- a/src/main/java/org/sopt/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/domain/auth/controller/AuthController.java
@@ -1,15 +1,13 @@
 package org.sopt.domain.auth.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.domain.auth.dto.request.LoginRequest;
 import org.sopt.domain.auth.dto.response.TokenResponse;
 import org.sopt.domain.auth.service.AuthService;
 import org.sopt.global.response.BaseResponse;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +18,11 @@ public class AuthController {
 
     @PostMapping("login")
     public BaseResponse<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
-        return BaseResponse.ok(authService.login(request.email(), request.password()));
+        return BaseResponse.ok(authService.login(request.email(), request.password()),"로그인 성공");
+    }
+
+    @PostMapping("reissue")
+    public BaseResponse<TokenResponse> reissue(@Parameter(hidden = true) @RequestHeader("Authorization") String refreshToken){
+        return BaseResponse.ok(authService.reissue(refreshToken),"Refresh Token 재발급 성공");
     }
 }

--- a/src/main/java/org/sopt/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/domain/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package org.sopt.domain.auth.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.auth.dto.request.LoginRequest;
+import org.sopt.domain.auth.dto.response.TokenResponse;
+import org.sopt.domain.auth.service.AuthService;
+import org.sopt.global.response.BaseResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("login")
+    public BaseResponse<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+        return BaseResponse.ok(authService.login(request.email(), request.password()));
+    }
+}

--- a/src/main/java/org/sopt/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/org/sopt/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,12 @@
+package org.sopt.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoginRequest(
+        @Schema(description = "이메일", example = "dlwjddus1112@naver.com")
+        String email,
+
+        @Schema(description = "비밀번호", example = "wjddus11")
+        String password
+) {
+}

--- a/src/main/java/org/sopt/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/org/sopt/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenResponse(
+        @Schema(description = "멤버 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "액세스 토큰")
+        String accessToken,
+
+        @Schema(description = "리프레시 토큰")
+        String refreshToken
+) {
+   public static TokenResponse of(Long memberId, String accessToken, String refreshToken) {
+           return new TokenResponse(memberId, accessToken, refreshToken);
+   }
+}

--- a/src/main/java/org/sopt/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/org/sopt/domain/auth/entity/RefreshToken.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RefreshToken {
     @Id
-    private Long userId;
+    private Long memberId;
 
     @Column(nullable = false, length = 500)
     private String refreshToken;

--- a/src/main/java/org/sopt/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/org/sopt/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,29 @@
+package org.sopt.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RefreshToken {
+    @Id
+    private Long userId;
+
+    @Column(nullable = false, length = 500)
+    private String refreshToken;
+
+    public static RefreshToken of(Long userId, String refreshToken) {
+        return new RefreshToken(userId, refreshToken);
+    }
+
+    public void updateToken(String token) {
+        this.refreshToken = token;
+    }
+}

--- a/src/main/java/org/sopt/domain/auth/errorcode/AuthErrorCode.java
+++ b/src/main/java/org/sopt/domain/auth/errorcode/AuthErrorCode.java
@@ -1,0 +1,25 @@
+package org.sopt.domain.auth.errorcode;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.global.exception.errorcode.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+    REFRESH_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Refresh Token이 존재하지 않습니다."),
+    REFRESH_MISMATHCES(HttpStatus.BAD_REQUEST.value(), "Refresh Token이 일치하지 않습니다."),
+    ;
+
+    private final int httpStatus;
+    private final String message;
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/sopt/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.domain.auth.repository;
+
+import org.sopt.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long userId);
+}

--- a/src/main/java/org/sopt/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/sopt/domain/auth/repository/RefreshTokenRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByUserId(Long userId);
+    Optional<RefreshToken> findByMemberId(Long userId);
 }

--- a/src/main/java/org/sopt/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/domain/auth/service/AuthService.java
@@ -1,0 +1,56 @@
+package org.sopt.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.auth.dto.response.TokenResponse;
+import org.sopt.domain.auth.entity.RefreshToken;
+import org.sopt.domain.auth.repository.RefreshTokenRepository;
+import org.sopt.domain.member.entity.Member;
+import org.sopt.domain.member.repository.MemberRepository;
+import org.sopt.global.exception.customexception.CustomException;
+import org.sopt.global.jwt.JwtProvider;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.sopt.domain.member.errorcode.MemberErrorCode.MEMBER_NOT_FOUND;
+import static org.sopt.domain.member.errorcode.MemberErrorCode.PASSWORD_MISMATCH;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private final JwtProvider jwtProvider;
+
+    private final MemberRepository memberRepository;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public TokenResponse login(String email, String password) {
+
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        checkPassword(password, member);
+
+        String accessToken = jwtProvider.generateAccessToken(member.getId());
+        String refreshToken = jwtProvider.generateRefreshToken(member.getId());
+
+        refreshTokenRepository.findByUserId(member.getId())
+                .ifPresentOrElse(
+                        existing -> existing.updateToken(refreshToken),
+                        () -> refreshTokenRepository.save(RefreshToken.of(member.getId(), refreshToken))
+                );
+
+        return TokenResponse.of(member.getId(), accessToken, refreshToken);
+
+    }
+
+    private void checkPassword(String password, Member member) {
+        if(!passwordEncoder.matches(password, member.getPassword())) {
+            throw new CustomException(PASSWORD_MISMATCH);
+        }
+    }
+
+
+}

--- a/src/main/java/org/sopt/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/domain/auth/service/AuthService.java
@@ -8,12 +8,16 @@ import org.sopt.domain.member.entity.Member;
 import org.sopt.domain.member.repository.MemberRepository;
 import org.sopt.global.exception.customexception.CustomException;
 import org.sopt.global.jwt.JwtProvider;
+import org.sopt.global.jwt.JwtUtil;
+import org.sopt.global.jwt.constant.HttpHeaderConstants;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.sopt.domain.auth.errorcode.AuthErrorCode.*;
 import static org.sopt.domain.member.errorcode.MemberErrorCode.MEMBER_NOT_FOUND;
 import static org.sopt.domain.member.errorcode.MemberErrorCode.PASSWORD_MISMATCH;
+import static org.sopt.global.exception.errorcode.GlobalErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +29,10 @@ public class AuthService {
     private final MemberRepository memberRepository;
 
     private final RefreshTokenRepository refreshTokenRepository;
+
     private final PasswordEncoder passwordEncoder;
+
+    private final JwtUtil jwtUtil;
 
     public TokenResponse login(String email, String password) {
 
@@ -36,7 +43,7 @@ public class AuthService {
         String accessToken = jwtProvider.generateAccessToken(member.getId());
         String refreshToken = jwtProvider.generateRefreshToken(member.getId());
 
-        refreshTokenRepository.findByUserId(member.getId())
+        refreshTokenRepository.findByMemberId(member.getId())
                 .ifPresentOrElse(
                         existing -> existing.updateToken(refreshToken),
                         () -> refreshTokenRepository.save(RefreshToken.of(member.getId(), refreshToken))
@@ -50,6 +57,29 @@ public class AuthService {
         if(!passwordEncoder.matches(password, member.getPassword())) {
             throw new CustomException(PASSWORD_MISMATCH);
         }
+    }
+
+    public TokenResponse reissue(String bearerToken) {
+        String refreshToken = bearerToken.replace(HttpHeaderConstants.BEARER_PREFIX, "").trim();
+        if(!jwtUtil.isTokenValid(refreshToken)) {
+            throw new CustomException(JWT_INVALID);
+        }
+
+        Long memberId = jwtUtil.extractMemberIdFromToken(refreshToken);
+
+        RefreshToken savedToken = refreshTokenRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CustomException(REFRESH_NOT_FOUND));
+
+        if (!savedToken.getRefreshToken().equals(refreshToken)) {
+            throw new CustomException(REFRESH_MISMATHCES);
+        }
+
+        String newAccessToken = jwtProvider.generateAccessToken(memberId);
+        String newRefreshToken = jwtProvider.generateRefreshToken(memberId);
+
+        savedToken.updateToken(newRefreshToken);
+
+        return TokenResponse.of(memberId, newAccessToken, newRefreshToken);
     }
 
 

--- a/src/main/java/org/sopt/domain/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/org/sopt/domain/member/dto/request/MemberCreateRequest.java
@@ -11,6 +11,9 @@ public record MemberCreateRequest(
         @Schema(description = "이름", example = "이정연")
         String name,
 
+        @Schema(description = "비밀번호", example = "1234")
+        String password,
+
         @NotBlank(message = "생년월일은 필수 입력 사항입니다.")
         @Schema(description = "생년월일", example = "2000-11-12")
         String birthDate,
@@ -24,6 +27,6 @@ public record MemberCreateRequest(
         String gender
 ) {
         public MemberCreateCommand toCommand() {
-            return new MemberCreateCommand(name, birthDate, email, gender);
+            return new MemberCreateCommand(name, password, birthDate, email, gender);
         }
 }

--- a/src/main/java/org/sopt/domain/member/entity/Member.java
+++ b/src/main/java/org/sopt/domain/member/entity/Member.java
@@ -22,6 +22,8 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
+    private String password;
+
     private String name;
 
     private LocalDate birthDate;
@@ -39,9 +41,10 @@ public class Member {
         article.setMember(this);
     }
 
-    public static Member create(String name, LocalDate birthDate, String email, Gender gender){
+    public static Member create(String name, String password, LocalDate birthDate, String email, Gender gender){
         return Member.builder()
                 .name(name)
+                .password(password)
                 .birthDate(birthDate)
                 .email(email)
                 .gender(gender)

--- a/src/main/java/org/sopt/domain/member/errorcode/MemberErrorCode.java
+++ b/src/main/java/org/sopt/domain/member/errorcode/MemberErrorCode.java
@@ -17,7 +17,8 @@ public enum MemberErrorCode implements ErrorCode {
     DUPLICATE_EMAIL(CONFLICT.value(),"중복된 이메일입니다."),
     MEMBER_NOT_FOUND(NOT_FOUND.value(), "존재하지 않는 회원입니다."),
     MEMBER_AGE_TOO_LOW(BAD_REQUEST.value(), "20세 미만의 회원은 가입이 불가능합니다."),
-    MEMBER_SAVE_FAILED(INTERNAL_SERVER_ERROR.value(),"회원 저장에 실패하였습니다.")
+    MEMBER_SAVE_FAILED(INTERNAL_SERVER_ERROR.value(),"회원 저장에 실패하였습니다."),
+    PASSWORD_MISMATCH(BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다.")
     ;
 
     private final int httpStatus;

--- a/src/main/java/org/sopt/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/sopt/domain/member/repository/MemberRepository.java
@@ -16,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     boolean existsByEmail(String email);
 
     void deleteById(Long id);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/org/sopt/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/sopt/domain/member/service/MemberServiceImpl.java
@@ -9,6 +9,7 @@ import org.sopt.domain.member.entity.Member;
 import org.sopt.domain.member.repository.MemberRepository;
 import org.sopt.domain.member.service.dto.request.MemberCreateCommand;
 import org.sopt.global.exception.customexception.CustomException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -22,11 +23,14 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
 
+    private final BCryptPasswordEncoder passwordEncoder;
+
     public Long join(MemberCreateCommand command) {
         checkEmailDuplicate(command.email());
 
         Member member = Member.create(
                 command.name(),
+                passwordEncoder.encode(command.password()),
                 LocalDate.parse(command.birthDate()),
                 command.email(),
                 Gender.valueOf(command.gender()));

--- a/src/main/java/org/sopt/domain/member/service/dto/request/MemberCreateCommand.java
+++ b/src/main/java/org/sopt/domain/member/service/dto/request/MemberCreateCommand.java
@@ -3,6 +3,8 @@ package org.sopt.domain.member.service.dto.request;
 public record MemberCreateCommand(
         String name,
 
+        String password,
+
         String birthDate,
 
         String email,

--- a/src/main/java/org/sopt/global/annotation/LoginMemberId.java
+++ b/src/main/java/org/sopt/global/annotation/LoginMemberId.java
@@ -1,0 +1,11 @@
+package org.sopt.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMemberId {
+}

--- a/src/main/java/org/sopt/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/global/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import org.sopt.global.jwt.CustomAccessDeniedHandler;
 import org.sopt.global.jwt.CustomAuthenticationEntryPoint;
 import org.sopt.global.jwt.JwtAuthenticationFilter;
 import org.sopt.global.jwt.JwtUtil;
-import org.sopt.global.jwt.constant.SwaggerPathConstants;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -27,9 +26,8 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
 
     public static final String[] ALLOWED_PATHS = {
-            SwaggerPathConstants.SWAGGER_CONFIG,
-            SwaggerPathConstants.SWAGGER_UI,
-            SwaggerPathConstants.SWAGGER_DOCS
+            "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-config",
+            "/auth/login", "/members", "/auth/reissue"
     };
 
     @Bean

--- a/src/main/java/org/sopt/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/global/config/SecurityConfig.java
@@ -1,0 +1,59 @@
+package org.sopt.global.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.global.jwt.CustomAccessDeniedHandler;
+import org.sopt.global.jwt.CustomAuthenticationEntryPoint;
+import org.sopt.global.jwt.JwtAuthenticationFilter;
+import org.sopt.global.jwt.JwtUtil;
+import org.sopt.global.jwt.constant.SwaggerPathConstants;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+
+    public static final String[] ALLOWED_PATHS = {
+            SwaggerPathConstants.SWAGGER_CONFIG,
+            SwaggerPathConstants.SWAGGER_UI,
+            SwaggerPathConstants.SWAGGER_DOCS
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers(ALLOWED_PATHS).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(auth -> auth
+                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                        .accessDeniedHandler(new CustomAccessDeniedHandler())
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/org/sopt/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/global/config/SwaggerConfig.java
@@ -1,0 +1,49 @@
+package org.sopt.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Bofit 백엔드 API 명세서 ",
+                description = "Springdoc을 이용한 Swagger API 문서입니다.",
+                version = "1.0"
+        )
+)
+
+@Configuration
+public class SwaggerConfig {
+    private final String securitySchemaName = "JWT";
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(setComponents())
+                .addSecurityItem(setSecurityItems());
+    }
+    private Components setComponents() {
+        return new Components()
+                .addSecuritySchemes(securitySchemaName, bearerAuth());
+    }
+
+    private SecurityScheme bearerAuth() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+    }
+
+    private SecurityRequirement setSecurityItems() {
+        return new SecurityRequirement()
+                .addList(securitySchemaName);
+    }
+}

--- a/src/main/java/org/sopt/global/config/WebConfig.java
+++ b/src/main/java/org/sopt/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package org.sopt.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.global.jwt.LoginArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginArgumentResolver loginArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginArgumentResolver);
+    }
+}

--- a/src/main/java/org/sopt/global/exception/errorcode/GlobalErrorCode.java
+++ b/src/main/java/org/sopt/global/exception/errorcode/GlobalErrorCode.java
@@ -17,7 +17,14 @@ public enum GlobalErrorCode implements ErrorCode {
     INVALID_JSON(HttpStatus.BAD_REQUEST.value(), "JSON 형식이 올바르지 않습니다."),
     MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST.value(), "필수 요청 파라미터가 누락되었습니다."),
     TYPE_MISMATCH(HttpStatus.BAD_REQUEST.value(), "요청 파라미터 타입이 일치하지 않습니다."),
-    MISSING_PATH_VARIABLE(HttpStatus.BAD_REQUEST.value(), "경로 변수 값이 누락되었습니다.")
+    MISSING_PATH_VARIABLE(HttpStatus.BAD_REQUEST.value(), "경로 변수 값이 누락되었습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN.value(), "권한이 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), "인증되지 않은 사용자입니다."),
+    JWT_USER_ID_EXTRACTION_FAILED(HttpStatus.UNAUTHORIZED.value(), "JWT에서 userId 추출 실패"),
+    JWT_INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED.value(), "잘못된 JWT 서명입니다."),
+    JWT_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "만료된 토큰입니다."),
+    JWT_UNSUPPORTED(HttpStatus.UNAUTHORIZED.value(), "지원하지 않는 JWT입니다."),
+    JWT_INVALID(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 JWT입니다.")
     ;
 
     private final int httpStatus;

--- a/src/main/java/org/sopt/global/exception/errorcode/GlobalErrorCode.java
+++ b/src/main/java/org/sopt/global/exception/errorcode/GlobalErrorCode.java
@@ -20,7 +20,7 @@ public enum GlobalErrorCode implements ErrorCode {
     MISSING_PATH_VARIABLE(HttpStatus.BAD_REQUEST.value(), "경로 변수 값이 누락되었습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN.value(), "권한이 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), "인증되지 않은 사용자입니다."),
-    JWT_USER_ID_EXTRACTION_FAILED(HttpStatus.UNAUTHORIZED.value(), "JWT에서 userId 추출 실패"),
+    JWT_MEMBER_ID_EXTRACTION_FAILED(HttpStatus.UNAUTHORIZED.value(), "JWT에서 memberId 추출 실패"),
     JWT_INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED.value(), "잘못된 JWT 서명입니다."),
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "만료된 토큰입니다."),
     JWT_UNSUPPORTED(HttpStatus.UNAUTHORIZED.value(), "지원하지 않는 JWT입니다."),

--- a/src/main/java/org/sopt/global/exception/errorcode/GlobalErrorCode.java
+++ b/src/main/java/org/sopt/global/exception/errorcode/GlobalErrorCode.java
@@ -24,7 +24,8 @@ public enum GlobalErrorCode implements ErrorCode {
     JWT_INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED.value(), "잘못된 JWT 서명입니다."),
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "만료된 토큰입니다."),
     JWT_UNSUPPORTED(HttpStatus.UNAUTHORIZED.value(), "지원하지 않는 JWT입니다."),
-    JWT_INVALID(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 JWT입니다.")
+    JWT_INVALID(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 JWT입니다."),
+    AUTHENTICATION_SETTING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR.value(), "인증 정보 처리에 실패했습니다")
     ;
 
     private final int httpStatus;

--- a/src/main/java/org/sopt/global/jwt/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/sopt/global/jwt/CustomAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package org.sopt.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.sopt.global.exception.errorcode.ErrorCode;
+import org.sopt.global.exception.errorcode.GlobalErrorCode;
+import org.sopt.global.response.BaseErrorResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        ErrorCode error = GlobalErrorCode.FORBIDDEN;
+        response.setStatus(error.getHttpStatus());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
+
+        String json = new ObjectMapper().writeValueAsString(BaseErrorResponse.of(error));
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/org/sopt/global/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/global/jwt/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,40 @@
+package org.sopt.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.sopt.global.exception.errorcode.ErrorCode;
+import org.sopt.global.exception.errorcode.GlobalErrorCode;
+import org.sopt.global.jwt.constant.RequestAttributeConstants;
+import org.sopt.global.response.BaseErrorResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+
+        ErrorCode error = GlobalErrorCode.UNAUTHORIZED;
+
+        var requestError = request.getAttribute(RequestAttributeConstants.EXCEPTION);
+        if(requestError instanceof ErrorCode errorCode){
+            error = errorCode;
+        }
+        response.setStatus(error.getHttpStatus());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
+
+        String json = new ObjectMapper().writeValueAsString(BaseErrorResponse.of(error));
+        response.getWriter().write(json);
+    }
+
+}

--- a/src/main/java/org/sopt/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/global/jwt/JwtAuthenticationFilter.java
@@ -73,7 +73,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private Authentication getAuthentication(String token) {
-        Long userId = jwtUtil.extractUserIdFromToken(token);
+        Long userId = jwtUtil.extractMemberIdFromToken(token);
         return new JwtTokenAuthentication(userId);
     }
 

--- a/src/main/java/org/sopt/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,80 @@
+package org.sopt.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.global.exception.customexception.CustomException;
+import org.sopt.global.jwt.constant.HttpHeaderConstants;
+import org.sopt.global.jwt.constant.RequestAttributeConstants;
+import org.sopt.global.jwt.constant.SwaggerPathConstants;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    private static final List<String> EXCLUDED_PATH_PREFIXES = List.of(
+            SwaggerPathConstants.SWAGGER_CONFIG,
+            SwaggerPathConstants.SWAGGER_UI,
+            SwaggerPathConstants.SWAGGER_DOCS
+    );
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        if(shouldNotFilter(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = getToken(request);
+
+        if(token != null) {
+            try {
+                if (jwtUtil.isTokenValid(token)) {
+                    Authentication authentication = getAuthentication(token);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            } catch (CustomException e) {
+                request.setAttribute(RequestAttributeConstants.EXCEPTION, e.getErrorCode());
+                throw e;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String uri = request.getRequestURI();
+        return EXCLUDED_PATH_PREFIXES.stream().anyMatch(uri::startsWith);
+    }
+
+    private String getToken(HttpServletRequest request) {
+        String authorization = request.getHeader(HttpHeaderConstants.AUTHORIZATION);
+        String validTokenPrefix = HttpHeaderConstants.BEARER_PREFIX;
+        if (authorization == null || !authorization.startsWith(validTokenPrefix)) {
+            return null;
+        }
+        return authorization.substring(validTokenPrefix.length()).trim();
+    }
+
+    private Authentication getAuthentication(String token) {
+        Long userId = jwtUtil.extractUserIdFromToken(token);
+        return new JwtTokenAuthentication(userId);
+    }
+
+}

--- a/src/main/java/org/sopt/global/jwt/JwtProvider.java
+++ b/src/main/java/org/sopt/global/jwt/JwtProvider.java
@@ -1,0 +1,37 @@
+package org.sopt.global.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.global.properties.JwtProperties;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+@Getter
+public class JwtProvider {
+
+    private final Long accessTokenExpireMillis;
+    private final SecretKey secretKey;
+
+    public JwtProvider(JwtProperties jwtProperties) {
+        this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpireMillis = jwtProperties.accessTokenExpiredAt();
+    }
+
+    public String generateAccessToken(Long userId) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpireMillis))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+}

--- a/src/main/java/org/sopt/global/jwt/JwtProvider.java
+++ b/src/main/java/org/sopt/global/jwt/JwtProvider.java
@@ -18,11 +18,13 @@ import java.util.Date;
 public class JwtProvider {
 
     private final Long accessTokenExpireMillis;
+    private final Long refreshTokenExpireMillis;
     private final SecretKey secretKey;
 
     public JwtProvider(JwtProperties jwtProperties) {
         this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
-        this.accessTokenExpireMillis = jwtProperties.accessTokenExpiredAt();
+        this.accessTokenExpireMillis = jwtProperties.accessTokenExpiration();
+        this.refreshTokenExpireMillis = jwtProperties.refreshTokenExpiration();
     }
 
     public String generateAccessToken(Long userId) {
@@ -30,6 +32,15 @@ public class JwtProvider {
                 .setSubject(String.valueOf(userId))
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpireMillis))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpireMillis))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/main/java/org/sopt/global/jwt/JwtTokenAuthentication.java
+++ b/src/main/java/org/sopt/global/jwt/JwtTokenAuthentication.java
@@ -1,0 +1,51 @@
+package org.sopt.global.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class JwtTokenAuthentication implements Authentication {
+
+    private final Long userId;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return userId;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return true;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return "";
+    }
+}

--- a/src/main/java/org/sopt/global/jwt/JwtUtil.java
+++ b/src/main/java/org/sopt/global/jwt/JwtUtil.java
@@ -1,0 +1,53 @@
+package org.sopt.global.jwt;
+
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.global.exception.customexception.CustomException;
+import org.springframework.stereotype.Component;
+
+import static org.sopt.global.exception.errorcode.GlobalErrorCode.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private final JwtProvider jwtProvider;
+
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(jwtProvider.getSecretKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | io.jsonwebtoken.security.SignatureException e) {
+            throw new CustomException(JWT_INVALID_SIGNATURE);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(JWT_EXPIRED);
+        } catch (UnsupportedJwtException e) {
+            throw new CustomException(JWT_UNSUPPORTED);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(JWT_INVALID);
+        } catch (Exception e) {
+            log.warn("Unexpected JWT error: {}", e.getMessage());
+            throw new CustomException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public Long extractUserIdFromToken(String token) {
+        try {
+            Claims claims = getClaims(token);
+            return Long.valueOf(claims.getSubject());
+        } catch (Exception e) {
+            throw new CustomException(JWT_USER_ID_EXTRACTION_FAILED);
+        }
+    }
+
+}

--- a/src/main/java/org/sopt/global/jwt/JwtUtil.java
+++ b/src/main/java/org/sopt/global/jwt/JwtUtil.java
@@ -41,12 +41,12 @@ public class JwtUtil {
         }
     }
 
-    public Long extractUserIdFromToken(String token) {
+    public Long extractMemberIdFromToken(String token) {
         try {
             Claims claims = getClaims(token);
             return Long.valueOf(claims.getSubject());
         } catch (Exception e) {
-            throw new CustomException(JWT_USER_ID_EXTRACTION_FAILED);
+            throw new CustomException(JWT_MEMBER_ID_EXTRACTION_FAILED);
         }
     }
 

--- a/src/main/java/org/sopt/global/jwt/LoginArgumentResolver.java
+++ b/src/main/java/org/sopt/global/jwt/LoginArgumentResolver.java
@@ -1,0 +1,46 @@
+package org.sopt.global.jwt;
+
+import org.sopt.global.annotation.LoginMemberId;
+import org.sopt.global.exception.customexception.CustomException;
+import org.sopt.global.exception.errorcode.GlobalErrorCode;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginMemberId.class) &&
+               parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        validateAuthentication(authentication);
+
+        return getUserIdFromAuthentication(authentication);
+    }
+
+    private void validateAuthentication(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    private Long getUserIdFromAuthentication(Authentication authentication) {
+        if (!(authentication instanceof JwtTokenAuthentication)) {
+            throw new CustomException(GlobalErrorCode.AUTHENTICATION_SETTING_FAIL);
+        }
+        return ((JwtTokenAuthentication) authentication).getUserId();
+    }
+}

--- a/src/main/java/org/sopt/global/jwt/constant/HttpHeaderConstants.java
+++ b/src/main/java/org/sopt/global/jwt/constant/HttpHeaderConstants.java
@@ -1,0 +1,6 @@
+package org.sopt.global.jwt.constant;
+
+public class HttpHeaderConstants {
+    public static final String AUTHORIZATION = "authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+}

--- a/src/main/java/org/sopt/global/jwt/constant/RequestAttributeConstants.java
+++ b/src/main/java/org/sopt/global/jwt/constant/RequestAttributeConstants.java
@@ -1,0 +1,11 @@
+package org.sopt.global.jwt.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RequestAttributeConstants {
+
+    public static final String EXCEPTION = "exception";
+
+}

--- a/src/main/java/org/sopt/global/jwt/constant/SwaggerPathConstants.java
+++ b/src/main/java/org/sopt/global/jwt/constant/SwaggerPathConstants.java
@@ -1,0 +1,11 @@
+package org.sopt.global.jwt.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SwaggerPathConstants {
+    public static final String SWAGGER_UI = "/swagger-ui";
+    public static final String SWAGGER_DOCS = "/v3/api-docs";
+    public static final String SWAGGER_CONFIG = "/swagger-config";
+}

--- a/src/main/java/org/sopt/global/properties/JwtProperties.java
+++ b/src/main/java/org/sopt/global/properties/JwtProperties.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "jwt")
 public record JwtProperties(
         String secret,
-        Long accessTokenExpiredAt
+        Long accessTokenExpiration,
+        Long refreshTokenExpiration
 ){
 }

--- a/src/main/java/org/sopt/global/properties/JwtProperties.java
+++ b/src/main/java/org/sopt/global/properties/JwtProperties.java
@@ -1,0 +1,10 @@
+package org.sopt.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        Long accessTokenExpiredAt
+){
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,4 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   accessTokenExpiration: ${JWT_ACCESS_EXPIRED_AT}
+  refreshTokenExpiration: ${JWT_REFRESH_EXPIRED_AT}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,6 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
     show-sql: true
+jwt:
+  secret: ${JWT_SECRET}
+  accessTokenExpiration: ${JWT_ACCESS_EXPIRED_AT}


### PR DESCRIPTION
# 🔥*Pull requests*

<br>


## **구현한 내용에 대해서 설명해주세요**

<br>

### JWT 발급 클래스

`JwtProvider` 클래스에서 토큰 발급을 담당합니다. 환경 변수를 통해 Secret Key와 만료 시간을 주입받고, Access Token과 Refresh Token을 발급합니다.

### JwtUtil

`JwtUtil` 클래스에서는 여러 유틸 메서드들을 제공합니다. 토큰의 유효성 검사, 그리고 토큰으로부터 Member의 정보를 받아오는 메서드들을 포함하고 있습니다.

### 커스텀 Authentication 클래스

`JwtTokenAuthentication`는 JWT 기반 인증 결과를 Spring Security의 Authentication 객체 형태로 표현하기 위한 최소 구현체입니다. 토큰을 검증하여 얻은 사용자 정보를 SecurityContext에 담기 위한 Authentication 객체입니다.

### 커스텀 AuthenticationEntryPoint 클래스

`CustomAuthenticationEntryPoint`는 인증되지 않은 사용자가 보호된 API에 접근했을 때(401) 실행되는 클래스입니다. JWT가 없거나, 만료되었거나, 위조되었을 때 발생하는 인증 예외(AuthenticationException)를 가로채서 일관된 JSON 에러 응답을 내려줍니다.

### 커스텀 AccessDeniedHandler 클래스

`CustomAccessDeniedHandler`는 인증은 되었으나 접근 권한이 없는 경우(403) 실행되는 핸들러입니다. 인증은 정상적으로 되었지만, 해당 리소스에 접근할 권한이 없는 경우 발생하는 AccessDeniedException을 가로채서 403 Forbidden 에러를 JSON 형태로 반환합니다. 기본 HTML 오류 페이지 대신 API 형태의 에러 응답을 내려줍니다.

### 커스텀 필터 클래스

`JwtAuthenticationFilter`는 모든 API 요청에서 JWT를 검사하여 인증 정보를 SecurityContext 에 등록하는 역할을 담당합니다. 인증이 필요 없는 경로는 필터링에서 제외했고, Authorization 헤더에서 JWT를 추출하여 인증 정보를 저장하는 역할을 합니다.

### 로그인 기능

이메일과 비밀번호가 DB에 저장된 데이터와 일치하면, accessToken과 refreshToken을 발급해줍니다. 
비밀번호는 `BcryptPasswordEncoder`를 통해 암호화하여 보안을 강화했습니다.

### 토큰 reissue

헤더로부터 넘어온 토큰을 파싱하여 토큰의 유효성을 검사하고, Member 정보를 추출하여 RefreshToken을 업데이트하고 AccessToken도 새로 발급해줍니다.

## **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

<br>

### RefreshToken 저장 위치

결론적으로는 RefreshToken을 DB에 저장하는 식으로 구현했습니다. 애플리케이션 자체 트래픽이 많지 않고, 로그인과 같은 트랜잭션 안에서 처리하기 쉽기 때문입니다.

### 환경변수 properties 분리

`@Value`를 통해 환경변수를 주입받는 방법보다 Properties 클래스를 통해 바인딩 받는 방법을 사용했는데, Properties 클래스를 사용하게 되면 유지보수에 유리한 면이 많다고 판단했습니다.

